### PR TITLE
Prevent widget rendering for posts without terms

### DIFF
--- a/same-category-posts.php
+++ b/same-category-posts.php
@@ -491,6 +491,11 @@ class Widget extends \WP_Widget {
 				}
 			}
 		}
+		
+		// If the current post has no terms for the selected taxonomy, don't render the widget.
+		if ( empty( $categories ) || is_wp_error( $categories ) ) {
+    	return;
+		}
 
 		// Excerpt length filter
 		if ( isset($instance["excerpt_length"]) && $instance["excerpt_length"] > 0 ) {


### PR DESCRIPTION
### Summary
This PR prevents a runtime issue that occurs when the Same Category Posts widget is displayed inside a WPBakery “Widgetised Sidebar” element and the current post has no terms in the taxonomy selected for the widget (for example, no tags).

### What Was Observed
On a production site using WPBakery Page Builder, the sidebar is rendered through the "Widgetised Sidebar" element, which outputs widgets via `dynamic_sidebar()`.

When viewing a post **without any tags**, the page returned a 500 Internal Server Error for the main HTML request.  
Adding a tag to the post or removing the Same Category Posts widget from the sidebar immediately resolved the issue.

On a separate test site (non–WP Engine environment) with debugging enabled, PHP warnings appeared in this situation:

- Undefined variable $term_query_in  
- Undefined variable $term_query_exclude  
- foreach(): argument must be of type array|object, bool given  
- Undefined variable $widgetHTML  

These warnings were triggered only when the post had **no terms** in the taxonomy configured for the widget, and they occurred consistently when the widget was rendered through the WPBakery Widgetised Sidebar structure.

### Cause
Inside the `widget()` method, `$categories` is populated using `get_the_terms()`.  
If the post has **no terms**, `get_the_terms()` returns `false`.

Later in the function, `$categories` is treated as an array and iterated over. This leads to warnings and, when the widget output is wrapped inside WPBakery’s rendering pipeline, the page can fail to render properly.

### Fix
This PR adds a defensive check immediately after `$categories` is gathered:

```php
// If the current post has no terms for the selected taxonomy, do not render the widget.
if ( empty( $categories ) || is_wp_error( $categories ) ) {
    return;
}
